### PR TITLE
Remove secret from settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SECRET_KEY = 'GOOGLE IT'
+
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+PORT = 8000

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # db
 *.sqlite3
+
+# envvars
+.env

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -12,6 +12,10 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 
+from dotenv import dotenv_values
+
+config = dotenv_values(".env")
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -20,13 +24,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-rvmo8js_uair0$uvbw5g@gz42r&s_cju$oksx^obw)&-qk1b03'
+SECRET_KEY = config["SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config["DEBUG"] == "True"
 
 ALLOWED_HOSTS = []
-
 
 # Application definition
 


### PR DESCRIPTION
# Why
* GitGuardian warned about the secret shared on repo.
# What
* Removed the secret from `settings.py`
* Added `.env`
* Did not rotate the key as the code is never deployed. ;P
